### PR TITLE
Allow parsing SAML responses with no assertions

### DIFF
--- a/tests/fixtures/adfs-response-with-no-assertion.xml
+++ b/tests/fixtures/adfs-response-with-no-assertion.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_UNIQUEID" Version="2.0" IssueInstant="2023-09-26T12:33:22.111Z" Destination="https://example.com/accounts/saml/acs/" Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified" InResponseTo="s-login-OTHER_ID">
+  <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://sso.example.com/adfs/services/trust</Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_UNIQUEID">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>...=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>...</ds:SignatureValue>
+    <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <ds:X509Data>
+        <ds:X509Certificate>...</ds:X509Certificate>
+      </ds:X509Data>
+    </KeyInfo>
+  </ds:Signature>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder"/>
+  </samlp:Status>
+</samlp:Response>

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,9 @@
+from smolsaml.models.saml_response import SAMLResponse
+from tests.conftest import fixtures_path
+
+
+def test_adfs_response_with_no_assertion() -> None:
+    xml = (fixtures_path / "adfs-response-with-no-assertion.xml").read_text()
+    r = SAMLResponse.from_xml(xml)
+    assert not r.assertion
+    assert r.status == "urn:oasis:names:tc:SAML:2.0:status:Responder"

--- a/tests/test_process_saml_response.py
+++ b/tests/test_process_saml_response.py
@@ -44,6 +44,7 @@ def test_keycloak_login_response(
         sp_configuration=example_sp_configuration,
         saml_response=keycloak_saml_response,
     )
+    assert resp.assertion
     assert (
         resp.assertion.subject
         and resp.assertion.subject.name_id == "G-580a44b3-c874-4cc5-b70e-d484cb49f9b5"


### PR DESCRIPTION
E.g. ADFS sends this with a `Responder` error code ("the Identity Provider blocked the authentication because of wrong/missing user permissions or service provider configurations").